### PR TITLE
Improvements to create_midi_gadget.sh

### DIFF
--- a/scripts/systemd/create_midi_gadget.sh
+++ b/scripts/systemd/create_midi_gadget.sh
@@ -1,5 +1,10 @@
 #! /bin/sh
 modprobe libcomposite
+if [ -d /sys/kernel/config/usb_gadget/midi ]; then
+  echo "usb midi gadget already exists" >&2
+  exit 0
+fi
+
 mkdir /sys/kernel/config/usb_gadget/midi
 cd /sys/kernel/config/usb_gadget/midi
 mkdir configs/c.1
@@ -15,3 +20,4 @@ echo "Conf 1" > configs/c.1/strings/0x409/configuration
 echo 120 > configs/c.1/MaxPower
 ln -s functions/midi.usb0 configs/c.1
 echo $(ls /sys/class/udc) > UDC
+echo "created usb midi gadget" >&2


### PR DESCRIPTION
- Mark file as executable (before this it would fail with a permissions issue until I manually ran chmod)

- Exit early if the top level gadget directory exists (before this, it would fail to mkdir and exit with an error). The aforementioned error made it impossible to restart `haxo.service`. Fixes https://github.com/cardonabits/haxo-rs/issues/22


---

I originally tried to make the script able to be run multiple times without error (e.g. I replaced `mkdir` with `mkdir -p`), but doing this for `ln` doesn't work easily, and the final `echo $(ls /sys/class/udc) > UDC` can't be run multiple times. So I think it's reasonable just to have the check right at the top.
