### PR TITLE
Add a new control mode for changing transposition

### DIFF
--- a/src/notemap.rs
+++ b/src/notemap.rs
@@ -17,7 +17,7 @@ pub struct NoteMap {
     record_next: bool,
     filename: String,
     notemap: BTreeMap<u32, i32>,
-    transpose: i32,
+    pub transpose: i32,
 }
 
 impl NoteMap {

--- a/src/notemap.rs
+++ b/src/notemap.rs
@@ -49,12 +49,17 @@ impl NoteMap {
     }
 
     pub fn get(&self, key: &u32) -> std::option::Option<i32> {
-	// Notemap is concert pitch, so add transpose to get midi value.
+        // Notemap is concert pitch, so add transpose to get midi value.
         self.notemap.get(key).map(|v| v + self.transpose)
     }
 
+    pub fn get_untransposed(&self, key: &u32) -> std::option::Option<i32> {
+        // Note in concert pitch. 
+        self.notemap.get(key).copied()
+    }
+
     pub fn get_name(&self, note: &i32) -> std::option::Option<&'static str> {
-	// Subtract transpose to convert from midi note to concert pitch.
+        // Subtract transpose to convert from midi note to concert pitch.
         midinotes::get_name(note - self.transpose)
     }
 

--- a/src/synth.rs
+++ b/src/synth.rs
@@ -2,6 +2,8 @@ extern crate fluidsynth;
 
 use fluidsynth::{audio, midi, settings, synth};
 use log::{info, warn};
+use std::thread;
+use std::time::Duration;
 
 use crate::alsa;
 
@@ -54,20 +56,20 @@ pub fn try_init(
     if !syn.set_polyphony(16) {
         warn!("Failed to set polyphony to 16");
     }
-    
+
     // Select bank 0
     syn.program_change(0, 0);
 
-	// Play the midi file
+    // Play the midi file
     let player = midi::Player::new(&mut syn);
     player.add("/usr/share/haxo/Startup_Haxophone.mid");
     player.play();
 
     // Wait until midi file is finished
-    while player.get_status() ==  midi::PlayerStatus::Playing {
+    while player.get_status() == midi::PlayerStatus::Playing {
         // wait ..
     }
-    
+
     // Switch off polyphony for sax
     if !syn.set_polyphony(1) {
         warn!("Failed to set polyphony to 1");
@@ -82,4 +84,12 @@ pub fn try_init(
     syn.program_change(0, banknum);
     println!("Synth created");
     (syn, settings, adriver)
+}
+
+pub fn beep(synth: &synth::Synth, note: i32, vol: i32) {
+    const MIDI_CC_VOLUME: i32 = 7;
+    synth.noteon(0, note, vol);
+    synth.cc(0, MIDI_CC_VOLUME, vol);
+    thread::sleep(Duration::from_millis(100));
+    synth.noteoff(0, note);
 }

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -1,0 +1,105 @@
+use std::thread;
+use std::time::Duration;
+
+use fluidsynth::synth::Synth;
+use log::info;
+
+use crate::notemap::NoteMap;
+use crate::synth::beep;
+
+#[derive(Copy, Clone, PartialEq)]
+enum TransposeCmd {
+    HalfStepUp,
+    HalfStepDown,
+    Direct(i32),
+    None,
+}
+
+// To set the transpose directly from a note we measure how far away from
+// the reference the note is. This is then used as the offset. We use high C
+// as the reference so we can fit soprano (High Bb -> -2), alto (Mid Eb -> -9),
+// tenor (Mid Bb, -> -14) and bari (Low Eb -> -21) within the reachable range.
+const TRANSPOSE_REFERENCE: i32 = 84;
+
+// Get the command associated with the given key state and volume.
+// For 'direct' transposition, the note must be played.
+fn get_cmd(key: u32, vol: i32, notemap: &NoteMap) -> TransposeCmd {
+    match (key, notemap.get_untransposed(&key), vol) {
+        (_, Some(note), v) if v > 10 => TransposeCmd::Direct(note),
+        (0x10000, None, _) => TransposeCmd::HalfStepUp,
+        (0x400000, None, _) => TransposeCmd::HalfStepDown,
+        _ => TransposeCmd::None,
+    }
+}
+
+pub(crate) struct Transpose<'a> {
+    synth: &'a Synth,
+    // Minimum time keys must be held to compute transpose.
+    countdown_init: u32,
+
+    // The command that will be applied when the timer expires.
+    cmd: TransposeCmd,
+    // How much time remains until command will be applied.
+    countdown: u32,
+    // Has the command already been applied.
+    applied: bool,
+}
+
+impl<'a> Transpose<'a> {
+    pub(crate) fn new(synth: &'a Synth, countdown_init: u32) -> Self {
+        Transpose {
+            synth,
+            countdown_init,
+            cmd: TransposeCmd::None,
+            countdown: 0,
+            applied: false,
+        }
+    }
+
+    pub(crate) fn process(self: &mut Self, key: u32, vol: i32, notemap: &mut NoteMap) {
+        let cur_cmd = get_cmd(key, vol, notemap);
+
+        // When the command changes, restart the countdown.
+        if cur_cmd != self.cmd {
+            self.cmd = cur_cmd;
+            self.countdown = self.countdown_init;
+            self.applied = false;
+            return;
+        }
+
+        self.countdown = self.countdown.saturating_sub(1);
+        if self.countdown > 0 || self.applied {
+            return;
+        }
+
+        // Apply the command.
+        match self.cmd {
+            TransposeCmd::HalfStepUp => self.offset(1, notemap),
+            TransposeCmd::HalfStepDown => self.offset(-1, notemap),
+            TransposeCmd::Direct(note) => self.direct(note, notemap),
+            TransposeCmd::None => (),
+        };
+        self.applied = true;
+    }
+
+    fn set_transpose(self: &mut Self, transpose: i32, notemap: &mut NoteMap) {
+        notemap.transpose = transpose;
+        info!("Set transpose to {transpose}");
+        // Beep reference note then transposed note.
+        beep(&self.synth, TRANSPOSE_REFERENCE, 50);
+        thread::sleep(Duration::from_millis(100));
+        beep(&self.synth, TRANSPOSE_REFERENCE + transpose, 50);
+    }
+
+    // Offset the tranpose amount by a number of half-steps.
+    fn offset(self: &mut Self, offset: i32, notemap: &mut NoteMap) {
+        self.set_transpose(notemap.transpose + offset, notemap);
+    }
+
+    // Jump directly to a transpose, based on the note played.
+    fn direct(self: &mut Self, note: i32, notemap: &mut NoteMap) {
+        // Compare note to reference to get transpose amount.
+        let transpose = note - TRANSPOSE_REFERENCE;
+        self.set_transpose(transpose, notemap);
+    }
+}

--- a/src/transpose.rs
+++ b/src/transpose.rs
@@ -21,13 +21,20 @@ enum TransposeCmd {
 // tenor (Mid Bb, -> -14) and bari (Low Eb -> -21) within the reachable range.
 const TRANSPOSE_REFERENCE: i32 = 84;
 
+// Keys used to change transpose by +/- a half step.
+const KEY_R1: u32 = 0x10000;
+const KEY_R3: u32 = 0x400000;
+
 // Get the command associated with the given key state and volume.
 // For 'direct' transposition, the note must be played.
 fn get_cmd(key: u32, vol: i32, notemap: &NoteMap) -> TransposeCmd {
-    match (key, notemap.get_untransposed(&key), vol) {
-        (_, Some(note), v) if v > 10 => TransposeCmd::Direct(note),
-        (0x10000, None, _) => TransposeCmd::HalfStepUp,
-        (0x400000, None, _) => TransposeCmd::HalfStepDown,
+    // Only enable +/- half stepping if neither key is in the notemap.
+    let step_ok = notemap.get(&KEY_R1).is_none() && notemap.get(&KEY_R3).is_none();
+
+    match (key, notemap.get_untransposed(&key)) {
+        (_, Some(note)) if vol > 10 => TransposeCmd::Direct(note),
+        (KEY_R1, None) if step_ok => TransposeCmd::HalfStepUp,
+        (KEY_R3, None) if step_ok => TransposeCmd::HalfStepDown,
         _ => TransposeCmd::None,
     }
 }


### PR DESCRIPTION
Implements https://github.com/cardonabits/haxo-rs/issues/19

* **Enter transpose mode:** Press keys for "Low B" and draw air for ~1 sec. Haxo will play two notes to indicate mode has started.
* **Jump directly to a transposition:** Press the keys you want a written "High C" to sound like (in concert pitch), and blow air until you hear two beeps in confirmation (concert "High C" and transposed "High C"). e.g. to get a tenor saxophone, play "Mid Bb" (which is 14 semitones below high C, which is how far below concert a tenor sax sounds). See table below
* **Further adjust the transposition:** press R1 to transpose up a half-step, press R3 to transpose down a half-step (same keys as for [changing instrument sounds](https://github.com/cardonabits/haxo-hw/blob/main/docs/instructions_safety.md#changing-instrument-sounds). You will hear two beeps in confirmation (concert "High C" and transposed "High C")
* **Exit transpose mode:** Press three left palm-keys. You will hear a single beep in confirmation.

Note to play to jump directly to transpositions of different saxophones:
| instrument | play |
| - | - |
| soprano | High Bb | 
| alto | Mid Eb |
| tenor | Mid Bb |
| bari | Low Eb |

@jcard0na I'm pretty happy with how the implementation turned out, but I'm happy to incorporate any feedback you may have