### PR TITLE
Added docker file that cross-compiles for Raspberry Pi Zero

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,7 @@
 
-# Cross-compiling for RPi Zero in docker (work in progress).
+# Cross-compiling for RPi Zero in docker
+
+- Note: targets other than RPi Zero aren't (yet) supported
 
 - Build the docker container
    `docker build docker/ -f docker/pizero.dockerfile -t pizero:local`
@@ -7,14 +9,10 @@
 - Run cargo build inside the docker container (this will mount the current
   directory inside the container).
    ```
-   docker run --rm --mount "type=bind,source=$(pwd),target=/haxo" pizero:local \
+   docker run --rm --mount "type=bind,source=$(pwd),target=/haxo" \
+      --mount "type=bind,source=$HOME/.cargo,target=/cargo" pizero:local \
       cargo build --target arm-unknown-linux-gnueabihf --release --features midi
    ```
-
-## TODO
-- Preserve cargo download cache (by mounting correct volume) 
-- Doesn't work with vergen?
-
 
 ## References
 - https://capnfabs.net/posts/cross-compiling-rust-apps-linker-shenanigans-multistrap-chroot/

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,21 @@
+
+# Cross-compiling for RPi Zero in docker (work in progress).
+
+- Build the docker container
+   `docker build docker/ -f docker/pizero.dockerfile -t pizero:local`
+
+- Run cargo build inside the docker container (this will mount the current
+  directory inside the container).
+   ```
+   docker run --rm --mount "type=bind,source=$(pwd),target=/haxo" pizero:local \
+      cargo build --target arm-unknown-linux-gnueabihf --release --features midi
+   ```
+
+## TODO
+- Preserve cargo download cache (by mounting correct volume) 
+- Doesn't work with vergen?
+
+
+## References
+- https://capnfabs.net/posts/cross-compiling-rust-apps-linker-shenanigans-multistrap-chroot/
+- https://earthly.dev/blog/cross-compiling-raspberry-pi/

--- a/docker/fix-sysroot.sh
+++ b/docker/fix-sysroot.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Fix broken symlinks in sysroot.
+#
+# Some libraries are installed with absolute paths, but they are now
+# nested within the /sysroot/ folder.
+
+find /sysroot/ -xtype l | while read link; do
+	fixed=/sysroot$(readlink $link)
+	if [[ -e $fixed ]]; then
+		ln -sf $fixed $link
+	else
+		echo "failed to fix symlink $link" >&2
+		exit 1
+	fi
+done

--- a/docker/fix-sysroot.sh
+++ b/docker/fix-sysroot.sh
@@ -4,6 +4,8 @@
 #
 # Some libraries are installed with absolute paths, but they are now
 # nested within the /sysroot/ folder.
+#
+# Inspired by https://capnfabs.net/posts/cross-compiling-rust-apps-linker-shenanigans-multistrap-chroot/
 
 find /sysroot/ -xtype l | while read link; do
 	fixed=/sysroot$(readlink $link)

--- a/docker/multistrap-config
+++ b/docker/multistrap-config
@@ -1,0 +1,19 @@
+[General]
+# Target architecture
+arch=armhf
+# Sysroot location
+directory=/sysroot/
+# Unpack the packages
+unpack=true
+# Tidy up afterwards (makes the container smaller)
+cleanup=true
+# Both of these refer to the 'Raspbian' stanza, below
+bootstrap=Raspbian
+aptsources=Raspbian
+
+[Raspbian]
+# Required packages for our build
+packages=libasound2-dev libdbus-1-dev libssl-dev libc6-dev libfluidsynth-dev
+source=http://raspbian.raspberrypi.org/raspbian/
+# Distribution version name
+suite=bullseye

--- a/docker/pizero.dockerfile
+++ b/docker/pizero.dockerfile
@@ -32,6 +32,7 @@ RUN rustup target add arm-unknown-linux-gnueabihf
 # Setup compilation environment variables.
 ENV PKG_CONFIG_LIBDIR_arm_unknown_linux_gnueabihf=/sysroot/usr/lib/arm-linux-gnueabihf/pkgconfig
 ENV PKG_CONFIG_SYSROOT_DIR_arm_unknown_linux_gnueabihf=/sysroot/
+ENV CARGO_HOME=/cargo
 ENV RUSTFLAGS="-C link-arg=--sysroot=/sysroot/ -C linker=/opt/x-tools/armv6-rpi-linux-gnueabihf/bin/armv6-rpi-linux-gnueabihf-gcc"
 
 # Change workdir (this is where the haxo source should get mounted).

--- a/docker/pizero.dockerfile
+++ b/docker/pizero.dockerfile
@@ -37,3 +37,5 @@ ENV RUSTFLAGS="-C link-arg=--sysroot=/sysroot/ -C linker=/opt/x-tools/armv6-rpi-
 
 # Change workdir (this is where the haxo source should get mounted).
 WORKDIR /haxo
+# Prevent git complaining about "detected dubious ownership in repository"
+RUN git config --global --add safe.directory /haxo

--- a/docker/pizero.dockerfile
+++ b/docker/pizero.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.75-bullseye
+FROM --platform=linux/amd64 rust:1.75-bullseye
 
 WORKDIR /setup
 

--- a/docker/pizero.dockerfile
+++ b/docker/pizero.dockerfile
@@ -1,0 +1,38 @@
+FROM rust:1.75-bullseye
+
+WORKDIR /setup
+
+RUN apt-get update && apt-get install multistrap gpg --assume-yes
+
+# This is where we'll create the sysroot for compilation.
+RUN mkdir /sysroot/
+
+# Install raspberry pi keyring.
+# We install it directly into the sysroot so that multistrap can use it.
+RUN mkdir -p /sysroot/etc/apt/trusted.gpg.d
+RUN curl -sL http://archive.raspbian.org/raspbian.public.key | gpg --import - \
+  && gpg --export 9165938D90FDDD2E \
+    > /sysroot/etc/apt/trusted.gpg.d/raspbian-archive-keyring.gpg
+
+# Setup the sysroot.
+COPY multistrap-config .
+RUN multistrap -f ./multistrap-config
+# Fix broken symlinks in the sysroot.
+COPY fix-sysroot.sh .
+RUN ./fix-sysroot.sh
+
+# Download the cross compiler.
+RUN mkdir -p /opt/
+RUN wget -q -O- https://github.com/tttapa/docker-arm-cross-toolchain/releases/latest/download/x-tools-armv6-rpi-linux-gnueabihf.tar.xz \
+  | tar xJ -C /opt
+
+# Add the rust target.
+RUN rustup target add arm-unknown-linux-gnueabihf
+
+# Setup compilation environment variables.
+ENV PKG_CONFIG_LIBDIR_arm_unknown_linux_gnueabihf=/sysroot/usr/lib/arm-linux-gnueabihf/pkgconfig
+ENV PKG_CONFIG_SYSROOT_DIR_arm_unknown_linux_gnueabihf=/sysroot/
+ENV RUSTFLAGS="-C link-arg=--sysroot=/sysroot/ -C linker=/opt/x-tools/armv6-rpi-linux-gnueabihf/bin/armv6-rpi-linux-gnueabihf-gcc"
+
+# Change workdir (this is where the haxo source should get mounted).
+WORKDIR /haxo


### PR DESCRIPTION
At the moment, https://github.com/cross-rs/cross doesn't support RPi Zero, due to it being the armv6 architecture. Trying to build a cross-rs image with packages from the raspian archive resulted in lots of problems with glibc, so this didn't work either.

Eventually, I pieced together parts from https://capnfabs.net/posts/cross-compiling-rust-apps-linker-shenanigans-multistrap-chroot/ and https://earthly.dev/blog/cross-compiling-raspberry-pi/ to come up with a docker file that uses multistrap to generate a RPi compatible sysroot, and then gets a linker from https://github.com/tttapa/docker-arm-cross-toolchain

The result is a docker image that you can build once with `docker build` and then call `docker run` to build (or incrementally rebuild) the haxo binary.

I imagine support for newer RPis will be much simpler to add, but for now at least (I have a RPi Zero 2 coming in the mail :)) I don't have anything else to test on, so I think it's worth submitting this as is.

This is much faster than building on the RPi Zero directly, and I've tested it on Mac M1 and Linux. Mac M1 is much slower than Linux because the container itself is amd64, which means that the Mac is natively arm, emulating amd64, to cross compile to arm. There's probably a better way, but at least it works...