### PR TITLE
Create github action compiling haxo001 for RPi Zero

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,26 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main", "testing-ci" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build docker/ -f docker/pizero.dockerfile -t pizero:local
+
+    - uses: actions/checkout@v4
+    - name: Build the haxo001 executable
+      run: |
+        docker run --rm --mount "type=bind,source=$(pwd),target=/haxo" \
+          --mount "type=bind,source=$HOME/.cargo,target=/cargo" pizero:local \
+          cargo build --target arm-unknown-linux-gnueabihf --release --features midi

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,3 @@
-
 # Cross-compiling for RPi Zero in docker
 
 - Note: targets other than RPi Zero aren't (yet) supported


### PR DESCRIPTION
Github Action to create cross-compilation container and compile haxo001 for the RPi Zero.

Enable manual triggering of this workflow.

Trigger this workflow on pushes the `testing-ci` branch as well.  This should be useful to test changes we make to the workflow as we add support for building other targets and/or build steps.