### PR TITLE
Update /boot/config.txt to /boot/firmware/config.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ to do that with with `raspi-config`.
 ### Sound Card
 
 To use the audio codec on the Haxo HAT, you need to load the `max98357a` driver.
-You can do that by editing `/boot/config.txt` as shown below
+You can do that by editing `/boot/firmware/config.txt` as shown below
 
 ```
 # Enable audio (loads snd_bcm2835)


### PR DESCRIPTION
Update path since `/boot/config.txt` has the following contents in the most recent RPi images:
```
DO NOT EDIT THIS FILE

The file you are looking for has moved to /boot/firmware/config.txt
```

Whereas `/boot/firmware/config.txt` matches the patterns mentioned in the instructions