### PR TITLE
MIDI out: change CC from volume to breath

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,10 +116,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         let pressure = sensor.read()?;
         let vol = max(0, pressure);
         const MIDI_CC_VOLUME: i32 = 7;
+        const MIDI_CC_BREATH: i32 = 2;
         if last_vol != vol {
             synth.cc(0, MIDI_CC_VOLUME, vol);
             #[cfg(feature = "midi")]
-            midi_out.cc(MIDI_CC_VOLUME, vol);
+            midi_out.cc(MIDI_CC_BREATH, vol);
             last_vol = vol;
         }
 
@@ -157,16 +158,12 @@ fn main() -> Result<(), Box<dyn Error>> {
                 if vol > 0 {
                     if last_note > 0 {
                         synth.cc(0, MIDI_CC_VOLUME, 0);
-                        #[cfg(feature = "midi")]
-                        midi_out.cc(MIDI_CC_VOLUME, 0);
                         synth.noteoff(0, last_note);
                         #[cfg(feature = "midi")]
                         midi_out.noteoff(last_note);
                         #[cfg(feature = "instrumentation")]
                         noteon_pin.set_low();
                         synth.cc(0, MIDI_CC_VOLUME, vol);
-                        #[cfg(feature = "midi")]
-                        midi_out.cc(MIDI_CC_VOLUME, vol);
                     }
                     synth.noteon(0, note, 127);
                     #[cfg(feature = "midi")]


### PR DESCRIPTION
Previously the midi output would use CC 7 (volume), which doesn't play nicely with external synthesizers as it changes the channel volume instead of the note "intensity".

Now, switch to CC 2 (breath) which more closely aligns to the intent of the command. Also remove code which momentarily dipped the output value to zero every time the note changed.

NOTE: This change means that synthesizers that do not support breath control will just receive a `noteon` message with `velocity = 127` anytime the haxophone reads non-zero breath pressure. Even when not blowing, the pressure value might oscillate between 0 and 1, causing frequent notes to sound.

If you are using the fluidsynth CLI as a midi synth, use `setbreathmode` to enable support for CC2 and fix the above issue.