### PR TITLE
Add .gitattributes to force LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Force LF to keep shell script shebangs working.
+* text=auto eol=lf
+
+*.sh text eol=lf
+
+# Known binary files.
+*.mid binary
+*.mp3 binary
+*.mscz binary
+*.pdf binary
+*.png binary


### PR DESCRIPTION
Windows checkouts with core.autocrlf=true corrupt shebangs in the .sh scripts, breaking the docker/podman cross-compile